### PR TITLE
Update build.gradle : building in 2020 with Android Studio 4.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ I'M NOT THE AUTHOR OF THE CODE AND ALL CREDITS GOES TO MichaelVL.
 
 Changelog:
 
-* Migrated to Android Studio 3.4.2
+* Migrated to Android Studio 4.4.1
 
 * http -> https for OSM API Queries
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     repositories {
-        jcenter()
+        google()
+        maven(){
+            url "https://repo1.maven.org/maven2/"
+        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.4.2'
@@ -11,9 +14,5 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
-        maven(){
-            url "https://maven.google.com"
-        }
     }
 }


### PR DESCRIPTION
Hello,

These are the changes I had to make in order to sucessfully build OSMFocus.
I'm not sure if this makes sense, first time using with android studio.

I have been looking forward to use OSMFocus again since it broke down in 2018 and couldn't get anything to work with MichaelVL's code. I recently found your code, thank you so much for fixing it!